### PR TITLE
There's no lionwiki systemd service ?

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -201,13 +201,6 @@ find $final_path/templates/minimaxing/minimaxing.css -type f -print0 | xargs -0 
 # find  :   -rw-r--r--  1 1001 1002  241 May  3 08:36 index.html   => GOOD
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Configuring SSOwat..." --weight=1

--- a/scripts/remove
+++ b/scripts/remove
@@ -23,17 +23,6 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #=================================================
 # STANDARD REMOVE
 #=================================================
-# REMOVE SERVICE INTEGRATION IN YUNOHOST
-#=================================================
-
-# Remove the service from the list of services known by Yunohost (added from `yunohost service add`)
-if ynh_exec_warn_less yunohost service status $app >/dev/null
-then
-	ynh_script_progression --message="Removing $app service integration..." --weight=1
-	yunohost service remove $app
-fi
-
-#=================================================
 # REMOVE APP MAIN DIR
 #=================================================
 ynh_script_progression --message="Removing app main directory..." --weight=2

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,13 +91,6 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=4
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
-# INTEGRATE SERVICE IN YUNOHOST
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX AND PHP-FPM

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -129,13 +129,6 @@ ynh_store_file_checksum --file="$final_path/menu.php"
 chown -R root: $final_path
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # RELOAD NGINX
 #=================================================
 ynh_script_progression --message="Reloading NGINX web server..." --weight=1


### PR DESCRIPTION
## Problem

c.f. https://forum.yunohost.org/t/lionwiki-fonctionnel-mais-service-lionwiki-t2t-is-unknown/13794

There's no lionwiki systemd service but "yunohost service add" is used anyway

## Solution

Don't "yunohost service add"

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
