### PR TITLE
Remove service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lionwiki-t2t for YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/lionwiki-t2t.svg)](https://dash.yunohost.org/appci/app/lionwiki-t2t) ![](https://ci-apps.yunohost.org/ci/badges/lionwiki-t2t.status.svg) ![](https://ci-apps.yunohost.org/ci/badges/lionwiki-t2t.maintain.svg)  
-[![Install Lionwiki-t2t with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=lionwiki-t2t)
+[![Install Lionwiki-t2t with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=lionwiki-t2t)
 
 *[Lire ce readme en français.](./README_fr.md)*
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,7 +1,7 @@
 # Lionwiki-t2t pour YunoHost
 
 [![Niveau d'intégration](https://dash.yunohost.org/integration/lionwiki-t2t.svg)](https://dash.yunohost.org/appci/app/lionwiki-t2t) ![](https://ci-apps.yunohost.org/ci/badges/lionwiki-t2t.status.svg) ![](https://ci-apps.yunohost.org/ci/badges/lionwiki-t2t.maintain.svg)  
-[![Installer Lionwiki-t2t avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=lionwiki-t2t)
+[![Installer Lionwiki-t2t avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=lionwiki-t2t)
 
 *[Read this readme in english.](./README.md)* 
 

--- a/check_process
+++ b/check_process
@@ -17,7 +17,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1	from_commit=02de615d477edb570687910e0e683d1ab073fe13
+		upgrade=1	from_commit=fde26800233eb9d312ef2885d747555c79ee779b
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -26,6 +26,6 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=02de615d477edb570687910e0e683d1ab073fe13
-		name=Create check_process
+	; commit=fde26800233eb9d312ef2885d747555c79ee779b
+		name=updating to latest lionwiki-t2t release
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&is_public=Yes&language=en&

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Lightweight wiki-style CMS using the txt2tags syntax",
         "fr": "CMS léger, géré sous forme de wiki utilisant la syntaxe txt2tags"
     },
-    "version": "3.2.11b~ynh5",
+    "version": "3.2.11b~ynh6",
     "url": "https://lionwiki-t2t.sourceforge.io/",
     "license": "MIT",
     "maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -201,13 +201,6 @@ find $final_path/templates/minimaxing/minimaxing.css -type f -print0 | xargs -0 
 # find  :   -rw-r--r--  1 1001 1002  241 May  3 08:36 index.html   => GOOD
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Configuring SSOwat..." --weight=1

--- a/scripts/remove
+++ b/scripts/remove
@@ -23,17 +23,6 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #=================================================
 # STANDARD REMOVE
 #=================================================
-# REMOVE SERVICE INTEGRATION IN YUNOHOST
-#=================================================
-
-# Remove the service from the list of services known by Yunohost (added from `yunohost service add`)
-if ynh_exec_warn_less yunohost service status $app >/dev/null
-then
-	ynh_script_progression --message="Removing $app service integration..." --weight=1
-	yunohost service remove $app
-fi
-
-#=================================================
 # REMOVE APP MAIN DIR
 #=================================================
 ynh_script_progression --message="Removing app main directory..." --weight=2

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,13 +91,6 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=4
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
-# INTEGRATE SERVICE IN YUNOHOST
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX AND PHP-FPM

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -129,13 +129,6 @@ ynh_store_file_checksum --file="$final_path/menu.php"
 chown -R root: $final_path
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
-#=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
-
-yunohost service add $app --description "Lightweight wiki-style CMS" --log "/var/log/$app/$app.log"
-
-#=================================================
 # RELOAD NGINX
 #=================================================
 ynh_script_progression --message="Reloading NGINX web server..." --weight=1


### PR DESCRIPTION
## Problem

- *#5 c.f. https://forum.yunohost.org/t/lionwiki-fonctionnel-mais-service-lionwiki-t2t-is-unknown/13794
There's no lionwiki systemd service but "yunohost service add" is used anyway*

## Solution
- *Remove "yunohost service add"*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/lionwiki-t2t_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/lionwiki-t2t_ynh%20PR-NUM-%20(USERNAME)/)  
